### PR TITLE
Fixed lighting bugs caused inside Chunk.setBlockState

### DIFF
--- a/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
+++ b/patches/minecraft/net/minecraft/world/chunk/Chunk.java.patch
@@ -33,7 +33,12 @@
              ExtendedBlockStorage extendedblockstorage = this.field_76652_q[j >> 4];
              boolean flag = false;
  
-@@ -556,14 +558,19 @@
+@@ -552,18 +554,24 @@
+                 extendedblockstorage = new ExtendedBlockStorage(j >> 4 << 4, this.field_76637_e.field_73011_w.func_191066_m());
+                 this.field_76652_q[j >> 4] = extendedblockstorage;
+                 flag = j >= i1;
++                net.minecraftforge.common.lighting.LightingHooks.initSkylightForSection(this.field_76637_e, this, extendedblockstorage); //Forge: Always initialize sections properly (See #3870 and #3879)
+             }
  
              extendedblockstorage.func_177484_a(i, j & 15, k, p_177436_2_);
  
@@ -55,7 +60,14 @@
                      this.field_76637_e.func_175713_t(p_177436_1_);
                  }
              }
-@@ -580,8 +587,7 @@
+@@ -574,14 +582,13 @@
+             }
+             else
+             {
+-                if (flag)
++                if (false) //Forge: Don't call generateSkylightMap (as it produces the wrong result; sections are initialized above). Never bypass relightBlock (See #3870)
+                 {
+                     this.func_76603_b();
                  }
                  else
                  {
@@ -65,7 +77,7 @@
  
                      if (j1 > 0)
                      {
-@@ -601,28 +607,19 @@
+@@ -601,28 +608,19 @@
                      }
                  }
  
@@ -98,7 +110,16 @@
                          this.field_76637_e.func_175690_a(p_177436_1_, tileentity1);
                      }
  
-@@ -738,6 +735,7 @@
+@@ -670,7 +668,7 @@
+         {
+             extendedblockstorage = new ExtendedBlockStorage(j >> 4 << 4, this.field_76637_e.field_73011_w.func_191066_m());
+             this.field_76652_q[j >> 4] = extendedblockstorage;
+-            this.func_76603_b();
++            net.minecraftforge.common.lighting.LightingHooks.initSkylightForSection(this.field_76637_e, this, extendedblockstorage); //Forge: generateSkylightMap produces the wrong result (See #3870)
+         }
+ 
+         this.field_76643_l = true;
+@@ -738,6 +736,7 @@
              k = this.field_76645_j.length - 1;
          }
  
@@ -106,7 +127,7 @@
          p_76612_1_.field_70175_ag = true;
          p_76612_1_.field_70176_ah = this.field_76635_g;
          p_76612_1_.field_70162_ai = k;
-@@ -778,7 +776,7 @@
+@@ -778,7 +777,7 @@
      {
          IBlockState iblockstate = this.func_177435_g(p_177422_1_);
          Block block = iblockstate.func_177230_c();
@@ -115,7 +136,7 @@
      }
  
      @Nullable
-@@ -786,6 +784,12 @@
+@@ -786,6 +785,12 @@
      {
          TileEntity tileentity = this.field_150816_i.get(p_177424_1_);
  
@@ -128,7 +149,7 @@
          if (tileentity == null)
          {
              if (p_177424_2_ == Chunk.EnumCreateEntityType.IMMEDIATE)
-@@ -795,14 +799,9 @@
+@@ -795,14 +800,9 @@
              }
              else if (p_177424_2_ == Chunk.EnumCreateEntityType.QUEUED)
              {
@@ -144,7 +165,7 @@
  
          return tileentity;
      }
-@@ -819,10 +818,11 @@
+@@ -819,10 +819,11 @@
  
      public void func_177426_a(BlockPos p_177426_1_, TileEntity p_177426_2_)
      {
@@ -157,7 +178,7 @@
          {
              if (this.field_150816_i.containsKey(p_177426_1_))
              {
-@@ -854,8 +854,9 @@
+@@ -854,8 +855,9 @@
  
          for (ClassInheritanceMultiMap<Entity> classinheritancemultimap : this.field_76645_j)
          {
@@ -168,7 +189,7 @@
      }
  
      public void func_76623_d()
-@@ -871,6 +872,7 @@
+@@ -871,6 +873,7 @@
          {
              this.field_76637_e.func_175681_c(classinheritancemultimap);
          }
@@ -176,7 +197,7 @@
      }
  
      public void func_76630_e()
-@@ -880,8 +882,8 @@
+@@ -880,8 +883,8 @@
  
      public void func_177414_a(@Nullable Entity p_177414_1_, AxisAlignedBB p_177414_2_, List<Entity> p_177414_3_, Predicate <? super Entity > p_177414_4_)
      {
@@ -187,7 +208,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -918,8 +920,8 @@
+@@ -918,8 +921,8 @@
  
      public <T extends Entity> void func_177430_a(Class <? extends T > p_177430_1_, AxisAlignedBB p_177430_2_, List<T> p_177430_3_, Predicate <? super T > p_177430_4_)
      {
@@ -198,7 +219,7 @@
          i = MathHelper.func_76125_a(i, 0, this.field_76645_j.length - 1);
          j = MathHelper.func_76125_a(j, 0, this.field_76645_j.length - 1);
  
-@@ -997,6 +999,8 @@
+@@ -997,6 +1000,8 @@
  
      protected void func_186034_a(IChunkGenerator p_186034_1_)
      {
@@ -207,7 +228,7 @@
          if (this.func_177419_t())
          {
              if (p_186034_1_.func_185933_a(this, this.field_76635_g, this.field_76647_h))
-@@ -1008,8 +1012,10 @@
+@@ -1008,8 +1013,10 @@
          {
              this.func_150809_p();
              p_186034_1_.func_185931_b(this.field_76635_g, this.field_76647_h);
@@ -218,7 +239,7 @@
      }
  
      public BlockPos func_177440_h(BlockPos p_177440_1_)
-@@ -1064,7 +1070,7 @@
+@@ -1064,7 +1071,7 @@
          {
              BlockPos blockpos = this.field_177447_w.poll();
  
@@ -227,7 +248,7 @@
              {
                  TileEntity tileentity = this.func_177422_i(blockpos);
                  this.field_76637_e.func_175690_a(blockpos, tileentity);
-@@ -1128,6 +1134,13 @@
+@@ -1128,6 +1135,13 @@
      @SideOnly(Side.CLIENT)
      public void func_186033_a(PacketBuffer p_186033_1_, int p_186033_2_, boolean p_186033_3_)
      {
@@ -241,7 +262,7 @@
          boolean flag = this.field_76637_e.field_73011_w.func_191066_m();
  
          for (int i = 0; i < this.field_76652_q.length; ++i)
-@@ -1176,10 +1189,16 @@
+@@ -1176,10 +1190,16 @@
          this.field_76646_k = true;
          this.func_76590_a();
  
@@ -258,7 +279,7 @@
      }
  
      public Biome func_177411_a(BlockPos p_177411_1_, BiomeProvider p_177411_2_)
-@@ -1244,13 +1263,13 @@
+@@ -1244,13 +1264,13 @@
                      BlockPos blockpos1 = blockpos.func_177982_a(k, (j << 4) + i1, l);
                      boolean flag = i1 == 0 || i1 == 15 || k == 0 || k == 15 || l == 0 || l == 15;
  
@@ -274,7 +295,7 @@
                              {
                                  this.field_76637_e.func_175664_x(blockpos2);
                              }
-@@ -1381,7 +1400,7 @@
+@@ -1381,7 +1401,7 @@
          {
              blockpos$mutableblockpos.func_181079_c(blockpos$mutableblockpos.func_177958_n(), l, blockpos$mutableblockpos.func_177952_p());
  
@@ -283,7 +304,7 @@
              {
                  this.field_76637_e.func_175664_x(blockpos$mutableblockpos);
              }
-@@ -1489,4 +1508,34 @@
+@@ -1489,4 +1509,34 @@
          QUEUED,
          CHECK;
      }

--- a/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
+++ b/src/main/java/net/minecraftforge/common/lighting/LightingHooks.java
@@ -1,0 +1,48 @@
+/*
+ * Minecraft Forge
+ * Copyright (c) 2016.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation version 2.1
+ * of the License.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package net.minecraftforge.common.lighting;
+
+import net.minecraft.world.EnumSkyBlock;
+import net.minecraft.world.World;
+import net.minecraft.world.chunk.Chunk;
+import net.minecraft.world.chunk.storage.ExtendedBlockStorage;
+
+public class LightingHooks
+{
+    public static void initSkylightForSection(final World world, final Chunk chunk, final ExtendedBlockStorage section)
+    {
+        if (world.provider.hasSkyLight())
+        {
+            for (int x = 0; x < 16; ++x)
+            {
+                for (int z = 0; z < 16; ++z)
+                {
+                    if (chunk.getHeightValue(x, z) <= section.getYLocation())
+                    {
+                        for (int y = 0; y < 16; ++y)
+                        {
+                            section.setSkyLight(x, y, z, EnumSkyBlock.SKY.defaultLightValue);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added LightingHooks
Skylight for sections is now handled by LightingHooks instead of
Chunk.generateSkylightMap
Chunk.setBlockState no longer suppresses call to relightBlock when a new
section is created